### PR TITLE
Error out gracefully if no LLDB command is given

### DIFF
--- a/lldbsh.py
+++ b/lldbsh.py
@@ -5,6 +5,10 @@ def sh(debugger, command, result, internal_dict):
   commands = command.split("|")
   lldb_cmd = commands[0]
 
+  if lldb_cmd == '':
+      print("No LLDB command given. Use: 'sh <LLDB command> | <shell command>'")
+      return
+
   interpreter = debugger.GetCommandInterpreter()
   rto = lldb.SBCommandReturnObject()
   interpreter.HandleCommand(lldb_cmd, rto)

--- a/lldbsh.py
+++ b/lldbsh.py
@@ -1,22 +1,22 @@
 import lldb
 import subprocess
 
-def sh(debugger, command, result, dict):
+def sh(debugger, command, result, internal_dict):
   commands = command.split("|")
   lldb_cmd = commands[0]
 
   interpreter = debugger.GetCommandInterpreter()
-  res = lldb.SBCommandReturnObject()
-  interpreter.HandleCommand(lldb_cmd, res)
+  rto = lldb.SBCommandReturnObject()
+  interpreter.HandleCommand(lldb_cmd, rto)
 
-  if not res.Succeeded():
+  if not rto.Succeeded():
       raise Exception("failed to execute lldb command!")
-  if not res.GetOutput():
+  if not rto.GetOutput():
       return
 
   if len(commands) == 1:
     # `sh command` is equivalent to `command`
-    print(res.GetOutput())
+    print(rto.GetOutput())
     return
   elif len(commands) == 2:
     # TODO support chaining?
@@ -24,7 +24,7 @@ def sh(debugger, command, result, dict):
 
   # TODO: Not sure what the underlying buffer is for HandleCommand, but
   # ideally do some check/optim for really large output.
-  output = res.GetOutput().encode('UTF-8')
+  output = rto.GetOutput().encode('UTF-8')
   proc = subprocess.Popen(shell_cmd, shell=True, stdin=subprocess.PIPE)
 
   # TODO?
@@ -37,7 +37,7 @@ def sh(debugger, command, result, dict):
       proc.kill()
       outs, errs = proc.communicate()
 
-def __lldb_init_module (debugger, dict):
+def __lldb_init_module (debugger, internal_dict):
   res = lldb.SBCommandReturnObject()
   interpreter = debugger.GetCommandInterpreter()
   interpreter.HandleCommand('command script delete sh', res)


### PR DESCRIPTION
Previously this caused a loop until the recursion depth was hit.
(plus minor cleanup)